### PR TITLE
feat(wordcount): add YAML options to control counting of code blocks and inline code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you're using version control, you will want to check in this directory.
 After installing:
 
 - Add
-  ```
+  ```yaml
   filters:
     - wordcount
   ```
@@ -34,6 +34,22 @@ For example you could write:
 > There are {{wordcount}} words in this document.
 
 and it will replace `{{wordcount}}` with its estimate.
+
+You can also include additional settings like the following to control whether inline code is counted in the word total:
+
+```yaml
+filters:
+  - wordcount
+wordcount:
+  count-code-blocks: false
+  count-inline-code: false
+```
+
+When true: 
+- `r 2+2` increases the count by 2.
+- `r 2 + 2` increases the count by 4.
+
+When set to false, inline code does not contribute to the word count.
 
 ## Example
 

--- a/example.qmd
+++ b/example.qmd
@@ -3,6 +3,9 @@ title: "Wordcount Example"
 subtitle: "Example with {{wordcount}} words"
 filters:
   - wordcount
+wordcount:
+  count-code-blocks: false
+  count-inline-code: false
 format: pdf
 references:
   - id: knuth1984
@@ -31,5 +34,17 @@ The number of words by section will be logged to the Quarto terminal.
 ### Lower-level headings
 
 Of course, low level headings can be used too.
+
+### Behavior of Inline Code
+
+There are two YAML parameters that control how code is counted:
+
+- **`count-code-blocks`** – includes or excludes fenced/indented code blocks (`CodeBlock` elements).
+- **`count-inline-code`** – includes or excludes inline code spans (`` `like this` ``).
+
+Both default to `true` for backward compatibility.  
+When `count-inline-code` is enabled, inline code counts each non-space token inside backticks.  
+For example, `` `r 2+2` `` adds **2** words, while `` `r 2 + 2` `` adds **4**.  
+Setting `count-inline-code: false` prevents inline code from affecting the total word count.
 
 ## References


### PR DESCRIPTION
This PR adds two optional parameters under the `wordcount` YAML key, allowing users to configure how code is handled in the word count filter.

### New options

```yaml
wordcount:
  count-code-blocks: false
  count-inline-code: false
```

### Behavior
- count-code-blocks — includes or excludes fenced/indented code blocks (CodeBlock elements).
- count-inline-code — includes or excludes inline code spans (`like this`).
Both default to true for backward compatibility.

When count-inline-code is enabled, inline code counts each non-space token inside backticks.
For example:
- `r 2+2` increases the count by 2
- `r 2 + 2` increases the count by 4

Similarly, by default previously codeblocks also increased the word count.

The following code block increased the wordcount by 3 

```r

2 + 2 

```

Meanwhile following increase it by 1.

```r

2+2 

```

When disabled, inline code and code blocks no longer contribute to the total word count.

### Example Usage

```yaml
filters:
  - wordcount
wordcount:
  count-code-blocks: false
  count-inline-code: false
```

This makes the filter more flexible for documents containing R code, Quarto inline evaluations, or code-heavy text, preventing artificial inflation of word counts.